### PR TITLE
update on tensorflow train example: object-detect's config file rewriting and file changing

### DIFF
--- a/examples/tensorflow/train/object-detection/README.md
+++ b/examples/tensorflow/train/object-detection/README.md
@@ -19,11 +19,20 @@ We use the pet detection as the example. The detailed info can be found in https
 Please follow the research/object\_detection/g3doc/running\_pets.md to download the training data and the pretrained model. The example use the resnet101 model and the Oxford-IIIT Pets Dataset.
 
 #### Create Local Test Data Path
-Suppose you have downloaded the dataset and use the object\_detection/dataset\_tools/create\_pet\_tf\_record.py to generate the tfrecords. We put all the tfrecord, the pet\_label\_map.pbtxt from object\_detection/data/ as well as the resnet101 ckpt into /data/object-detect/data/. 
+Suppose you have downloaded the dataset and use the object\_detection/dataset\_tools/create\_pet\_tf\_record.py to generate the tfrecords. We put all the tfrecord, the pet\_label\_map.pbtxt from object\_detection/data/ as well as the resnet101 ckpt into /data/object-detect/data/.
+Note that the tf record file type could be changed in future version of tensorflow examples. Please keep notice on how the tf record is maintained for future refence in the coming sections. Here lies the version of file names and types for the April 30, 2018 release of Models/Research/Object-detect module.
 
     # cd /data/object-detect/data/
     # ls
-    model.ckpt.data-00000-of-00001  model.ckpt.index  model.ckpt.meta  pet_label_map.pbtxt  pet_train_with_masks.record  pet_val_with_masks.record
+    model.ckpt.data-00000-of-00001  model.ckpt.index  model.ckpt.meta  pet_label_map.pbtxt  
+    pet_faces_train.record-00000-of-00010  pet_faces_train.record-00001-of-00010  pet_faces_train.record-00002-of-00010
+    pet_faces_train.record-00003-of-00010  pet_faces_train.record-00004-of-00010  pet_faces_train.record-00005-of-00010
+    pet_faces_train.record-00006-of-00010  pet_faces_train.record-00007-of-00010  pet_faces_train.record-00008-of-00010
+    pet_faces_train.record-00009-of-00010
+    pet_faces_train.val-00000-of-00010  pet_faces_train.val-00001-of-00010  pet_faces_train.val-00002-of-00010
+    pet_faces_train.val-00003-of-00010  pet_faces_train.val-00004-of-00010  pet_faces_train.val-00005-of-00010
+    pet_faces_train.val-00006-of-00010  pet_faces_train.val-00007-of-00010  pet_faces_train.val-00008-of-00010
+    pet_faces_train.val-00009-of-00010
 
 #### Preparing the running config
 We also put the modified faster\_rcnn\_resnet101\_pets.config into /data/object-detect/data/. The modifications includes:
@@ -32,33 +41,46 @@ We also put the modified faster\_rcnn\_resnet101\_pets.config into /data/object-
       fine_tune_checkpoint: "/data/data/model.ckpt"
       
     Line 125:
-        input_path: "/data/data/pet_train_with_masks.record"
+        input_path: "/data/data/pet_faces_train.record*"
       }
       label_map_path: "/data/data/pet_label_map.pbtxt"
     
     Line 139:
-        input_path: "/data/data/pet_val_with_masks.record"
+        input_path: "/data/data/pet_faces_val.record*"
       }
       label_map_path: "/data/data/pet_label_map.pbtxt"
       
 All the modifications are necessary to running the train job on UAI Train Platform. The UAI Train Platform will automatically put the data into /data/data/ path. We have provided the modified faster\_rcnn\_resnet101\_pets.config in uai-sdk/examples/tensorflow/train/object-detection/samples/
 
+Note that the "/data/data/pet_faces_val.record*" matches the file name and format discussed in Create Local Test Data Path. If the files generated to be tf record are modified in later version of Tensorflow, change the config file accordingly so it matches all the files generated, or kindly refer to the config file offered within the Tensorflow project:
+https://github.com/tensorflow/models/blob/master/research/object_detection/samples/configs/faster_rcnn_resnet101_pets.config
+
 Now the /data/object-detect/data/ include following files:
 
     # ls
-    faster_rcnn_resnet101_pets.config  model.ckpt.data-00000-of-00001  model.ckpt.index  model.ckpt.meta  pet_label_map.pbtxt  pet_train_with_masks.record  pet_val_with_masks.record
+    faster_rcnn_resnet101_pets.config  
+    pet_faces_train.record-00000-of-00010  pet_faces_train.record-00001-of-00010  pet_faces_train.record-00002-of-00010
+    pet_faces_train.record-00003-of-00010  pet_faces_train.record-00004-of-00010  pet_faces_train.record-00005-of-00010
+    pet_faces_train.record-00006-of-00010  pet_faces_train.record-00007-of-00010  pet_faces_train.record-00008-of-00010
+    pet_faces_train.record-00009-of-00010
+    pet_faces_train.val-00000-of-00010  pet_faces_train.val-00001-of-00010  pet_faces_train.val-00002-of-00010
+    pet_faces_train.val-00003-of-00010  pet_faces_train.val-00004-of-00010  pet_faces_train.val-00005-of-00010
+    pet_faces_train.val-00006-of-00010  pet_faces_train.val-00007-of-00010  pet_faces_train.val-00008-of-00010
+    pet_faces_train.val-00009-of-00010
+    model.ckpt.index  model.ckpt.meta  pet_label_map.pbtxt  pet_train_with_masks.record  pet_val_with_masks.record
 
 ### Build the Docker images
 We provide the basic Dockerfile to build the docker image for training object-detection model:
 
-    From uhub.service.ucloud.cn/uaishare/gpu_uaitrain_ubuntu-14.04_python-2.7.6_tensorflow-1.4.0:v1.0
+    From uhub.service.ucloud.cn/uaishare/cpu_uaiservice_ubuntu-16.04_python-2.7.6_tensorflow-1.6.0:v1.0
 
-    RUN apt-get update 
+    RUN apt-get update
     RUN apt-get install python-tk -y
 
     ADD ./research /data/
 
     RUN cd /data/ && python setup.py install && cd slim && python setup.py install
+
 
 We should run the docker build under PATH\_TO/tensorflow/models/. To build the docker image, we do the following steps:
 

--- a/examples/tensorflow/train/object-detection/samples/faster_rcnn_resnet101_pets.config
+++ b/examples/tensorflow/train/object-detection/samples/faster_rcnn_resnet101_pets.config
@@ -89,10 +89,6 @@ train_config: {
         manual_step_learning_rate {
           initial_learning_rate: 0.0003
           schedule {
-            step: 0
-            learning_rate: .0003
-          }
-          schedule {
             step: 900000
             learning_rate: .00003
           }
@@ -122,7 +118,7 @@ train_config: {
 
 train_input_reader: {
   tf_record_input_reader {
-    input_path: "/data/data/pet_train_with_masks.record"
+    input_path: "/data/data/pet_faces_train.record*"
   }
   label_map_path: "/data/data/pet_label_map.pbtxt"
 }
@@ -136,7 +132,7 @@ eval_config: {
 
 eval_input_reader: {
   tf_record_input_reader {
-    input_path: "/data/data/pet_val_with_masks.record"
+    input_path: "/data/data/pet_faces_val.record*"
   }
   label_map_path: "/data/data/pet_label_map.pbtxt"
   shuffle: false


### PR DESCRIPTION
The most recent release information of the Models/Research/Object-detect related to this change is as below.
Latest commit 7bf8934
Release information
April 30, 2018

We have released a Faster R-CNN detector with ResNet-101 feature extractor trained on [AVA](https://research.google.com/ava/) v2.1.
Compared with other commonly used object detectors, it changes the action classification loss function to per-class Sigmoid loss to handle boxes with multiple labels.
The model is trained on the training split of AVA v2.1 for 1.5M iterations, it achieves mean AP of 11.25% over 60 classes on the validation split of AVA v2.1.
For more details please refer to this [paper](https://arxiv.org/abs/1705.08421).

Thanks to contributors: Chen Sun, David Ross


Details:
Code for training within the newest version of Tensorflow is altered and no longer recognizes:

schedule {
            step: 0
            learning_rate: .0003
          }
Therefore it is removed.
Also, the newest create_pet_tf_record.py script creates batches of files in th form of pet_faces_val.record-00000-of-00010 and so on. The config file is changed accordingly on line 121 and line 135 to be the corresponding line.

The README is changed accordingly about the file changes and config rewriting.